### PR TITLE
Update sweep.py for successful run

### DIFF
--- a/sweep.py
+++ b/sweep.py
@@ -82,7 +82,7 @@ def sweep(
                 generation_config.exit_layer = exit_layer
                 generation_config.num_speculations = num_speculations
 
-                metric_result = benchmark(
+                metric_result, _ = benchmark(
                     model, tokenizer, benchmark_arguments, generation_config, args.seed
                 )
 


### PR DESCRIPTION
It had an error "The index of a tuple must be int or float, cannot be str".
Therefor, I add ", _" in line 85 to debug it, as the output result of benchmark function is a tuple of 2 items:(metric_result, empty dict) 